### PR TITLE
feat: add category model and repository

### DIFF
--- a/backend/migrations/20241123185053_categories.down.sql
+++ b/backend/migrations/20241123185053_categories.down.sql
@@ -1,0 +1,2 @@
+-- Add down migration script here
+DROP TABLE IF EXISTS "categories";

--- a/backend/migrations/20241123185053_categories.up.sql
+++ b/backend/migrations/20241123185053_categories.up.sql
@@ -1,0 +1,7 @@
+-- Add up migration script here
+DROP TABLE IF EXISTS "categories";
+CREATE TABLE "categories" (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name VARCHAR(255) NOT NULL,
+    description TEXT
+);

--- a/backend/migrations/20241123185157_add_foreignkey_for_prod.up.sql
+++ b/backend/migrations/20241123185157_add_foreignkey_for_prod.up.sql
@@ -1,0 +1,7 @@
+-- Add up migration script here
+
+ALTER TABLE "products"
+ADD CONSTRAINT fk_category
+FOREIGN KEY (category_id)
+REFERENCES categories(id)
+ON DELETE CASCADE;

--- a/backend/src/api/category.rs
+++ b/backend/src/api/category.rs
@@ -1,0 +1,143 @@
+use poem_openapi::param::Path;
+use poem_openapi::{payload::Json, OpenApi, ApiResponse, Object, Tags};
+use sqlx::PgPool;
+use uuid::Uuid;
+use crate::models::category::Category;
+use crate::database::category_repository::CategoryRepository;
+
+use super::products::ProductsResponse;
+
+#[derive(Tags)]
+enum ApiTags {
+    Categories,
+}
+
+#[derive(ApiResponse)]
+enum CategoryResponse {
+    #[oai(status = 200)]
+    Ok(Json<Category>),
+    #[oai(status = 404)]
+    NotFound,
+    #[oai(status = 500)]
+    InternalServerError,
+}
+
+#[derive(ApiResponse)]
+enum CategoriesResponse {
+    #[oai(status = 200)]
+    Ok(Json<Vec<Category>>),
+    #[oai(status = 500)]
+    InternalServerError,
+}
+
+#[derive(Object)]
+struct CreateCategoryRequest {
+    name: String,
+    description: Option<String>,
+}
+
+#[derive(Object)]
+struct UpdateCategoryRequest {
+    name: String,
+    description: Option<String>,
+}
+
+pub struct CategoryApi {
+    repository: CategoryRepository,
+}
+
+impl CategoryApi {
+    pub fn new(pool: PgPool) -> Self {
+        CategoryApi {
+            repository: CategoryRepository::new(pool),
+        }
+    }
+}
+
+#[OpenApi]
+impl CategoryApi {
+    #[oai(path = "/categories", method = "get", tag = "ApiTags::Categories")]
+    async fn get_categories(&self) -> CategoriesResponse {
+        match self.repository.get_all().await {
+            Ok(categories) => CategoriesResponse::Ok(Json(categories)),
+            Err(_) => CategoriesResponse::InternalServerError,
+        }
+    }
+
+    #[oai(path = "/categories/:id", method = "get", tag = "ApiTags::Categories")]
+    async fn get_category(&self, id: Path<Uuid>) -> CategoryResponse {
+        match self.repository.get_by_id(id.0).await {
+            Ok(category) => CategoryResponse::Ok(Json(category)),
+            Err(sqlx::Error::RowNotFound) => CategoryResponse::NotFound,
+            Err(_) => CategoryResponse::InternalServerError,
+        }
+    }
+
+    #[oai(path = "/categories", method = "post", tag = "ApiTags::Categories")]
+    async fn create_category(&self, category: Json<CreateCategoryRequest>) -> CategoryResponse {
+
+        let new_category = Category {
+            id: Uuid::new_v4(),
+            name: category.name.clone(),
+            description: category.description.clone(),
+        };
+
+        match new_category.validate() {
+            Ok(_) => match self.repository.create(new_category).await {
+                Ok(category) => CategoryResponse::Ok(Json(category)),
+                Err(_) => CategoryResponse::InternalServerError,
+            },
+            Err(e) => {
+                println!("{}", e);
+                CategoryResponse::InternalServerError
+            }
+        }
+    }
+
+    #[oai(path = "/categories/:id", method = "put", tag = "ApiTags::Categories")]
+    async fn update_category(
+        &self,
+        id: Path<Uuid>,
+        category: Json<UpdateCategoryRequest>,
+    ) -> CategoryResponse {
+        let updated_category = Category {
+            id: id.0,
+            name: category.name.clone(),
+            description: category.description.clone(),
+        };
+
+        match updated_category.validate() {
+            Ok(_) => match self.repository.update(id.0, &updated_category).await {
+                Ok(_) => CategoryResponse::Ok(Json(updated_category)),
+                Err(sqlx::Error::RowNotFound) => CategoryResponse::NotFound,
+                Err(_) => CategoryResponse::InternalServerError,
+            },
+            Err(e) => {
+                println!("{}", e);
+                CategoryResponse::InternalServerError
+            }
+        }
+    }
+
+    #[oai(path = "/categories/:id", method = "delete", tag = "ApiTags::Categories")]
+    async fn delete_category(&self, id: Path<Uuid>) -> CategoryResponse {
+        match self.repository.delete(id.0).await {
+            Ok(_) => CategoryResponse::Ok(Json(Category {
+                id: id.0,
+                name: "".to_string(),
+                description: None,
+            })),
+            Err(sqlx::Error::RowNotFound) => CategoryResponse::NotFound,
+            Err(_) => CategoryResponse::InternalServerError,
+        }
+    }
+
+    #[oai(path = "/categories/:id/products", method = "get", tag = "ApiTags::Categories")]
+    async fn get_products_by_category(&self, id: Path<Uuid>) -> ProductsResponse {
+        match self.repository.get_products_by_category(id.0).await {
+            Ok(products) => ProductsResponse::Ok(Json(products)),
+            Err(_) => ProductsResponse::InternalServerError,
+        }
+    }
+    
+}

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -1,1 +1,2 @@
 pub mod products;
+pub mod category;

--- a/backend/src/api/products.rs
+++ b/backend/src/api/products.rs
@@ -23,7 +23,7 @@ enum ProductResponse {
 
 
 #[derive(ApiResponse)]
-enum ProductsResponse {
+pub enum ProductsResponse {
     #[oai(status = 200)]
     Ok(Json<Vec<Product>>),
     #[oai(status = 500)]

--- a/backend/src/database/category_repository.rs
+++ b/backend/src/database/category_repository.rs
@@ -1,0 +1,121 @@
+use sqlx::PgPool;
+use uuid::Uuid;
+use crate::models::{category::Category, product::Product};
+
+pub struct CategoryRepository {
+    pool: PgPool,
+}
+
+impl CategoryRepository {
+    pub fn new(pool: PgPool) -> Self {
+        CategoryRepository { pool }
+    }
+
+    pub async fn get_all(&self) -> Result<Vec<Category>, sqlx::Error> {
+        sqlx::query_as::<_, Category>("SELECT * FROM categories")
+            .fetch_all(&self.pool)
+            .await
+    }
+
+    pub async fn get_by_id(&self, id: Uuid) -> Result<Category, sqlx::Error> {
+        sqlx::query_as::<_, Category>("SELECT * FROM categories WHERE id = $1")
+            .bind(id)
+            .fetch_one(&self.pool)
+            .await
+    }
+
+    pub async fn create(&self, category: Category) -> Result<Category, sqlx::Error> {
+        let category = sqlx::query_as::<_, Category>(
+            "INSERT INTO categories (name, description) VALUES ($1, $2) RETURNING *",
+        )
+        .bind(&category.name)
+        .bind(&category.description)
+        .fetch_one(&self.pool)
+        .await;
+        category
+    }
+
+    pub async fn update(&self, id: Uuid, category: &Category) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            "UPDATE categories SET name = $1, description = $2 WHERE id = $3",
+        )
+        .bind(&category.name)
+        .bind(&category.description)
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn delete(&self, id: Uuid) -> Result<(), sqlx::Error> {
+        sqlx::query("DELETE FROM categories WHERE id = $1")
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn get_all_paginated(
+        &self,
+        page: usize,
+        per_page: usize,
+    ) -> Result<Vec<Category>, sqlx::Error> {
+        let offset = (page - 1) * per_page;
+        sqlx::query_as::<_, Category>(
+            "SELECT * FROM categories ORDER BY name LIMIT $1 OFFSET $2"
+        )
+        .bind(per_page as i64)
+        .bind(offset as i64)
+        .fetch_all(&self.pool)
+        .await
+    }
+
+    pub async fn get_filtered(
+        &self,
+        name: Option<String>,
+        page: usize,
+        per_page: usize,
+    ) -> Result<Vec<Category>, sqlx::Error> {
+        let offset = (page - 1) * per_page;
+        let query = if let Some(name) = name {
+            sqlx::query_as::<_, Category>(
+                "SELECT * FROM categories WHERE name ILIKE $1 ORDER BY name LIMIT $2 OFFSET $3"
+            )
+            .bind(format!("%{}%", name))
+            .bind(per_page as i64)
+            .bind(offset as i64)
+        } else {
+            sqlx::query_as::<_, Category>(
+                "SELECT * FROM categories ORDER BY name LIMIT $1 OFFSET $2"
+            )
+            .bind(per_page as i64)
+            .bind(offset as i64)
+        };
+        query.fetch_all(&self.pool).await
+    }
+
+    pub async fn get_by_name(&self, name: &str) -> Result<Category, sqlx::Error> {
+        sqlx::query_as::<_, Category>("SELECT * FROM categories WHERE name = $1")
+            .bind(name)
+            .fetch_one(&self.pool)
+            .await
+    }
+
+    pub async fn get_products_by_category(&self, category_id: Uuid) -> Result<Vec<Product>, sqlx::Error> {
+        sqlx::query_as::<_, Product>("SELECT * FROM products WHERE category_id = $1")
+            .bind(category_id)
+            .fetch_all(&self.pool)
+            .await
+    }
+
+    pub async fn exists(&self, category_id: Uuid) -> Result<bool, sqlx::Error> {
+        let result = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM categories WHERE id = $1"
+        )
+        .bind(category_id)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(result > 0)
+    }
+}

--- a/backend/src/database/mod.rs
+++ b/backend/src/database/mod.rs
@@ -1,1 +1,2 @@
 pub mod product_repository;
+pub mod category_repository;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -20,13 +20,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .expect("Failed to create pool");
 
     let products_api = api::products::ProductApi::new(pool.clone());
+    let categories_api = api::category::CategoryApi::new(pool);
 
-    let api_service = OpenApiService::new(products_api, "My API", "1.0").server("0.0.0.0:8080");
+    let api_service = OpenApiService::new((categories_api,products_api), "КондиДария API", "1.0").server("http://localhost:8000/api");
 
     let ui = api_service.swagger_ui();
 
     let app = Route::new().nest("/api", api_service).nest("/", ui);
-    Server::new(TcpListener::bind("0.0.0.0:8080"))
+    Server::new(TcpListener::bind("0.0.0.0:8000"))
         .run(app)
         .await?;
 

--- a/backend/src/models/category.rs
+++ b/backend/src/models/category.rs
@@ -1,0 +1,20 @@
+use poem_openapi::Object;
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+use uuid::Uuid;
+
+#[derive(Debug, Serialize, Deserialize, Object, FromRow)]
+pub struct Category {
+    pub id: Uuid,
+    pub name: String,
+    pub description: Option<String>,
+}
+
+impl Category {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.name.is_empty() {
+            return Err("Category name cannot be empty".to_string());
+        }
+        Ok(())
+    }
+}

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -1,1 +1,2 @@
 pub mod product;
+pub mod category;


### PR DESCRIPTION
- Created a new `Category` model with fields `id`, `name`, and `description`.
- Added a `CategoryRepository` for handling database operations related to categories.
- Created migrations for the `categories` table in the database.
- Linked `products` table with `categories` via a foreign key `category_id`.

This change allows for managing product categories and enforcing data integrity between products and categories.